### PR TITLE
Multiple JACKETT URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ A modern web application for searching and downloading audiobooks from Audiobook
 ### Required Configuration
 
 #### Jackett Configuration (Required)
+- Multiple URLs are supported when prefixed JACKETT_API_URL
 ```env
 JACKETT_API_URL=https://jackett.example.com/api/v2.0/indexers/audiobookbay/results
+JACKETT_API_URL1=https://jackett.example.com/api/v2.0/indexers/myanonamouse/results
 JACKETT_API_KEY=your_jackett_api_key
 ```
 
@@ -209,6 +211,7 @@ pip install -r requirements.txt
 # Set environment variables
 export AUTH_MODE=none
 export JACKETT_API_URL=...
+export JACKETT_API_URL2=...
 export JACKETT_API_KEY=...
 # ... other variables
 

--- a/audiobookbay.py
+++ b/audiobookbay.py
@@ -1,8 +1,24 @@
 import requests
-from constants import JACKETT_API_KEY, JACKETT_API_URL
+from constants import JACKETT_API_KEY  #, JACKETT_API_URLS  # expect JACKETT_API_URLS to be a list
 from utils import custom_logger
+import os
 
 logger = custom_logger(__name__)
+
+
+
+def get_jackett_urls():
+    urls = []
+    for key, value in os.environ.items():
+        if key.startswith("JACKETT_API_URL"):
+            urls.append(value)
+    # sort for consistency (important if ordering matters)
+    urls.sort()
+    return urls
+
+JACKETT_API_URLS = get_jackett_urls()
+
+
 
 def get_jackett_magnet(url):
     """Convert URL to magnet link if needed"""
@@ -18,24 +34,37 @@ def get_jackett_magnet(url):
     return url
 
 def search_audiobook(query):
-    """Search for audiobooks using Jackett API"""
+    """
+    Search for audiobooks using multiple Jackett API URLs.
+    Combine and deduplicate results.
+    """
     params = {
         "apikey": JACKETT_API_KEY,
         "Query": query,
         "Category": "audiobooks"
     }
-    logger.info(f"Searching for {query}...")
+    all_results = []
+    seen_ids = set()
 
-    try:
-        response = requests.get(str(JACKETT_API_URL), params=params)
-        if response.status_code != 200:
-            logger.error("Error fetching results from Jackett:", response.text)
-            return []
+    # Ensure JACKETT_API_URLS is a list, e.g. [JACKETT_API_URL, JACKETT_API_URL1, ...]
+    for url in JACKETT_API_URLS:
+        logger.info(f"Searching for {query} on {url}...")
+        try:
+            response = requests.get(str(url), params=params)
+            if response.status_code != 200:
+                logger.error(f"Error fetching results from {url}: {response.text}")
+                continue
 
-        results = response.json()
-        logger.info(f"Found {len(results.get('Results', []))} results for {query}")
-        return results.get("Results", [])
-    except Exception as e:
-        logger.error(f"Search failed: {e}")
-        return []
+            results = response.json()
+            for item in results.get("Results", []):
+                # Deduplicate by Jackett's 'Guid' field, adjust if needed
+                result_id = item.get("Guid") or item.get("Title")
+                if result_id and result_id not in seen_ids:
+                    all_results.append(item)
+                    seen_ids.add(result_id)
+        except Exception as e:
+            logger.error(f"Search failed for {url}: {e}")
+            continue
 
+    logger.info(f"Found {len(all_results)} total results for {query} across all Jackett servers")
+    return all_results

--- a/docker-compose.external.yml
+++ b/docker-compose.external.yml
@@ -9,6 +9,8 @@ services:
     environment:
       # Jackett Configuration (External)
       - JACKETT_API_URL=https://jackett.example.com/api/v2.0/indexers/audiobookbay/results
+      - JACKETT_API_URL2=http://jackett:9117/api/v2.0/indexers/myanonamouse/results
+      - JACKETT_API_URL3=http://jackett:9117/api/v2.0/indexers/1337x/results
       - JACKETT_API_KEY=your_jackett_api_key_here
       
       # Torrent Client Configuration (External - choose one)

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -9,6 +9,8 @@ services:
     environment:
       # Jackett Configuration (Internal)
       - JACKETT_API_URL=http://jackett:9117/api/v2.0/indexers/audiobookbay/results
+      - JACKETT_API_URL2=http://jackett:9117/api/v2.0/indexers/myanonamouse/results
+      - JACKETT_API_URL3=http://jackett:9117/api/v2.0/indexers/1337x/results
       - JACKETT_API_KEY=your_jackett_api_key_here  # Set after Jackett setup
       
       # Transmission Configuration (Internal)


### PR DESCRIPTION
Multiple URL for JACKETT so can add different repos, it combines the outputs.
Future can add display of the source, but works for now.