### PR TITLE
feat: add multi-tenant support for Goodreads integration

### DIFF
--- a/source/abb/goodreads.py
+++ b/source/abb/goodreads.py
@@ -4,15 +4,14 @@ from .audiobookbay import search_audiobook
 from .torrent_service import add_torrent
 from .models import User
 from .goodreads_db import (
-    get_config, save_config, update_poll_status,
-    get_processed_book, add_processed_book, get_all_processed_books
+    get_config, update_poll_status,
+    get_processed_book, add_processed_book,
+    get_enabled_configs
 )
 from .utils import custom_logger
 
 logger = custom_logger(__name__)
 
-# RSS URL with pagination and sorting support
-# sort=date_added&order=d = latest first, per_page max is 200
 GOODREADS_RSS_URL = "https://www.goodreads.com/review/list_rss/{user_id}?shelf={shelf}&sort=date_added&order=d&per_page=200&page={page}"
 
 
@@ -20,21 +19,16 @@ def build_rss_url(user_id: str, shelf: str, page: int = 1) -> str:
     return GOODREADS_RSS_URL.format(user_id=user_id, shelf=shelf, page=page)
 
 
-def fetch_goodreads_shelf(user_id: str, shelf: str, max_pages: int = 10) -> List[Dict[str, Any]]:
+def fetch_goodreads_shelf(goodreads_user_id: str, shelf: str, max_pages: int = 10) -> List[Dict[str, Any]]:
     """
     Fetch all books from a Goodreads shelf with pagination.
     Returns books sorted by date_added descending (latest first).
-    
-    Args:
-        user_id: Goodreads user ID (numeric)
-        shelf: Shelf name (e.g., 'to-read')
-        max_pages: Maximum pages to fetch (default 10 = up to 2000 books)
     """
     all_books = []
     page = 1
     
     while page <= max_pages:
-        url = build_rss_url(user_id, shelf, page)
+        url = build_rss_url(goodreads_user_id, shelf, page)
         logger.info(f"Fetching Goodreads RSS page {page}: {url}")
         
         try:
@@ -45,7 +39,6 @@ def fetch_goodreads_shelf(user_id: str, shelf: str, max_pages: int = 10) -> List
                 break
             
             if not feed.entries:
-                # No more entries, stop pagination
                 logger.info(f"No more entries on page {page}, stopping pagination")
                 break
             
@@ -62,7 +55,6 @@ def fetch_goodreads_shelf(user_id: str, shelf: str, max_pages: int = 10) -> List
             
             logger.info(f"Page {page}: fetched {len(feed.entries)} books (total: {len(all_books)})")
             
-            # If we got less than 200, we've reached the last page
             if len(feed.entries) < 200:
                 break
             
@@ -106,31 +98,26 @@ def download_best_match(title: str, user: User) -> Optional[Dict[str, Any]]:
     return None
 
 
-def poll_and_download() -> Dict[str, Any]:
-    config = get_config()
-    
-    if not config.get("enabled"):
-        logger.info("Goodreads polling is disabled")
-        return {"status": "disabled", "message": "Polling is disabled"}
-    
-    user_id = config.get("user_id")
+def poll_and_download_for_user(user_id: str, config: Dict[str, Any]) -> Dict[str, Any]:
+    """Poll and download books for a specific user based on their config."""
+    goodreads_user_id = config.get("goodreads_user_id")
     shelf = config.get("shelf", "to-read")
     
-    if not user_id:
-        logger.warning("Goodreads user_id not configured")
-        update_poll_status("error", "User ID not configured")
-        return {"status": "error", "message": "User ID not configured"}
+    if not goodreads_user_id:
+        logger.warning(f"Goodreads user_id not configured for user {user_id}")
+        update_poll_status(user_id, "error", "Goodreads User ID not configured")
+        return {"status": "error", "message": "Goodreads User ID not configured", "user_id": user_id}
     
-    logger.info(f"Starting Goodreads poll for user {user_id}, shelf '{shelf}'")
+    logger.info(f"Starting Goodreads poll for user {user_id}, goodreads_user_id {goodreads_user_id}, shelf '{shelf}'")
     
     try:
-        books = fetch_goodreads_shelf(user_id, shelf)
+        books = fetch_goodreads_shelf(goodreads_user_id, shelf)
         
         if not books:
-            update_poll_status("success", "No books found on shelf")
-            return {"status": "success", "message": "No books on shelf", "processed": 0}
+            update_poll_status(user_id, "success", "No books found on shelf")
+            return {"status": "success", "message": "No books on shelf", "processed": 0, "user_id": user_id}
         
-        system_user = User(username="goodreads", role="admin", id="goodreads-auto")
+        torrent_user = User(username=f"goodreads-{user_id}", role="admin", id=user_id)
         
         new_downloads = 0
         skipped = 0
@@ -144,15 +131,16 @@ def poll_and_download() -> Dict[str, Any]:
             if not book_id or not title:
                 continue
             
-            existing = get_processed_book(book_id)
+            existing = get_processed_book(user_id, book_id)
             if existing:
                 skipped += 1
                 continue
             
-            result = download_best_match(title, system_user)
+            result = download_best_match(title, torrent_user)
             
             if result:
                 add_processed_book(
+                    user_id=user_id,
                     book_id=book_id,
                     title=title,
                     author=author,
@@ -162,6 +150,7 @@ def poll_and_download() -> Dict[str, Any]:
                 new_downloads += 1
             else:
                 add_processed_book(
+                    user_id=user_id,
                     book_id=book_id,
                     title=title,
                     author=author,
@@ -170,12 +159,13 @@ def poll_and_download() -> Dict[str, Any]:
                 no_results += 1
         
         message = f"Downloaded: {new_downloads}, No results: {no_results}, Skipped: {skipped}"
-        update_poll_status("success", message)
-        logger.info(f"Poll complete: {message}")
+        update_poll_status(user_id, "success", message)
+        logger.info(f"Poll complete for user {user_id}: {message}")
         
         return {
             "status": "success",
             "message": message,
+            "user_id": user_id,
             "new_downloads": new_downloads,
             "no_results": no_results,
             "skipped": skipped
@@ -183,16 +173,62 @@ def poll_and_download() -> Dict[str, Any]:
         
     except Exception as e:
         error_msg = f"Poll failed: {str(e)}"
-        logger.error(error_msg)
-        update_poll_status("error", error_msg)
-        return {"status": "error", "message": error_msg}
+        logger.error(f"Poll failed for user {user_id}: {error_msg}")
+        update_poll_status(user_id, "error", error_msg)
+        return {"status": "error", "message": error_msg, "user_id": user_id}
 
 
-def validate_goodreads_config(user_id: str, shelf: str) -> Dict[str, Any]:
-    if not user_id:
-        return {"valid": False, "message": "User ID is required"}
+def poll_and_download() -> Dict[str, Any]:
+    """Poll and download books for all enabled users."""
+    enabled_configs = get_enabled_configs()
     
-    books = fetch_goodreads_shelf(user_id, shelf)
+    if not enabled_configs:
+        logger.info("No enabled Goodreads configurations found")
+        return {"status": "disabled", "message": "No enabled configurations", "results": []}
+    
+    results = []
+    total_downloads = 0
+    total_errors = 0
+    
+    for config in enabled_configs:
+        user_id = config.get("user_id")
+        if not user_id:
+            continue
+            
+        result = poll_and_download_for_user(user_id, config)
+        results.append(result)
+        
+        if result.get("status") == "success":
+            total_downloads += result.get("new_downloads", 0)
+        else:
+            total_errors += 1
+    
+    return {
+        "status": "success",
+        "message": f"Polled {len(results)} users, {total_downloads} new downloads, {total_errors} errors",
+        "results": results,
+        "total_users": len(results),
+        "total_downloads": total_downloads,
+        "total_errors": total_errors
+    }
+
+
+def poll_and_download_single_user(user_id: str) -> Dict[str, Any]:
+    """Poll and download books for a single specific user."""
+    config = get_config(user_id)
+    
+    if not config.get("enabled"):
+        logger.info(f"Goodreads polling is disabled for user {user_id}")
+        return {"status": "disabled", "message": "Polling is disabled for this user", "user_id": user_id}
+    
+    return poll_and_download_for_user(user_id, config)
+
+
+def validate_goodreads_config(goodreads_user_id: str, shelf: str) -> Dict[str, Any]:
+    if not goodreads_user_id:
+        return {"valid": False, "message": "Goodreads User ID is required"}
+    
+    books = fetch_goodreads_shelf(goodreads_user_id, shelf)
     
     if books:
         return {
@@ -203,5 +239,5 @@ def validate_goodreads_config(user_id: str, shelf: str) -> Dict[str, Any]:
     else:
         return {
             "valid": False,
-            "message": f"Could not fetch books. Check user ID ({user_id}) and shelf name ({shelf})"
+            "message": f"Could not fetch books. Check Goodreads user ID ({goodreads_user_id}) and shelf name ({shelf})"
         }

--- a/source/abb/goodreads_db.py
+++ b/source/abb/goodreads_db.py
@@ -1,24 +1,53 @@
 import os
 from datetime import datetime
 from typing import Optional, List, Dict, Any
-from .constants import DB_PATH
+from .constants import DB_PATH, ADMIN_ID
 from tinydb import TinyDB, Query
 
 # Database for Goodreads configuration and processed books
 goodreadsdb = TinyDB(os.path.join(DB_PATH, "goodreads.json"))
 
-# Config table stores: user_id, shelf, poll_interval, enabled, last_poll
-# Processed table stores: book_id, title, author, added_date, downloaded_date, torrent_id, status
+# Config table stores: user_id, goodreads_user_id, shelf, poll_interval, enabled, last_poll
+# Processed table stores: user_id, book_id, title, author, added_date, downloaded_date, torrent_id, status
 
-CONFIG_DOC_ID = "config"
+CONFIG_DOC_TYPE = "config"
+PROCESSED_DOC_TYPE = "processed_book"
 
 
-def get_config() -> Dict[str, Any]:
-    """Get Goodreads configuration from database."""
-    entry = goodreadsdb.get(Query().doc_type == CONFIG_DOC_ID)
+def _migrate_legacy_config() -> None:
+    """
+    Migrate legacy single-user config to multi-tenant format.
+    If a config without user_id exists, assume it belongs to admin and migrate it.
+    """
+    q = Query()
+    legacy_config = goodreadsdb.get((q.doc_type == CONFIG_DOC_TYPE) & (~q.user_id.exists()))
+    
+    if legacy_config:
+        goodreadsdb.update(
+            {"user_id": ADMIN_ID},
+            (q.doc_type == CONFIG_DOC_TYPE) & (~q.user_id.exists())
+        )
+    
+    legacy_books = goodreadsdb.search((q.doc_type == PROCESSED_DOC_TYPE) & (~q.user_id.exists()))
+    if legacy_books:
+        for book in legacy_books:
+            goodreadsdb.update(
+                {"user_id": ADMIN_ID},
+                (q.doc_type == PROCESSED_DOC_TYPE) & (q.book_id == book.get("book_id")) & (~q.user_id.exists())
+            )
+
+
+_migrate_legacy_config()
+
+
+def get_config(user_id: str) -> Dict[str, Any]:
+    """Get Goodreads configuration for a specific user."""
+    q = Query()
+    entry = goodreadsdb.get((q.doc_type == CONFIG_DOC_TYPE) & (q.user_id == user_id))
     if entry:
         return {
             "user_id": entry.get("user_id", ""),
+            "goodreads_user_id": entry.get("goodreads_user_id", ""),
             "shelf": entry.get("shelf", "to-read"),
             "poll_interval": entry.get("poll_interval", 60),
             "enabled": entry.get("enabled", False),
@@ -27,7 +56,8 @@ def get_config() -> Dict[str, Any]:
             "last_poll_message": entry.get("last_poll_message"),
         }
     return {
-        "user_id": "",
+        "user_id": user_id,
+        "goodreads_user_id": "",
         "shelf": "to-read",
         "poll_interval": 60,
         "enabled": False,
@@ -37,57 +67,101 @@ def get_config() -> Dict[str, Any]:
     }
 
 
+def get_all_configs() -> List[Dict[str, Any]]:
+    """Get all Goodreads configurations for all users."""
+    q = Query()
+    configs = goodreadsdb.search(q.doc_type == CONFIG_DOC_TYPE)
+    return [
+        {
+            "user_id": entry.get("user_id", ""),
+            "goodreads_user_id": entry.get("goodreads_user_id", ""),
+            "shelf": entry.get("shelf", "to-read"),
+            "poll_interval": entry.get("poll_interval", 60),
+            "enabled": entry.get("enabled", False),
+            "last_poll": entry.get("last_poll"),
+            "last_poll_status": entry.get("last_poll_status"),
+            "last_poll_message": entry.get("last_poll_message"),
+        }
+        for entry in configs
+    ]
+
+
+def get_enabled_configs() -> List[Dict[str, Any]]:
+    """Get all enabled Goodreads configurations."""
+    q = Query()
+    configs = goodreadsdb.search((q.doc_type == CONFIG_DOC_TYPE) & (q.enabled == True))
+    return [
+        {
+            "user_id": entry.get("user_id", ""),
+            "goodreads_user_id": entry.get("goodreads_user_id", ""),
+            "shelf": entry.get("shelf", "to-read"),
+            "poll_interval": entry.get("poll_interval", 60),
+            "enabled": entry.get("enabled", False),
+            "last_poll": entry.get("last_poll"),
+            "last_poll_status": entry.get("last_poll_status"),
+            "last_poll_message": entry.get("last_poll_message"),
+        }
+        for entry in configs
+    ]
+
+
 def save_config(
     user_id: str,
+    goodreads_user_id: str,
     shelf: str = "to-read",
     poll_interval: int = 60,
     enabled: bool = False
 ) -> Dict[str, Any]:
-    """Save Goodreads configuration to database."""
+    """Save Goodreads configuration for a specific user."""
+    q = Query()
     config_data = {
-        "doc_type": CONFIG_DOC_ID,
+        "doc_type": CONFIG_DOC_TYPE,
         "user_id": user_id,
+        "goodreads_user_id": goodreads_user_id,
         "shelf": shelf,
         "poll_interval": poll_interval,
         "enabled": enabled,
     }
     
-    existing = goodreadsdb.get(Query().doc_type == CONFIG_DOC_ID)
+    existing = goodreadsdb.get((q.doc_type == CONFIG_DOC_TYPE) & (q.user_id == user_id))
     if existing:
-        # Preserve last_poll info when updating config
         config_data["last_poll"] = existing.get("last_poll")
         config_data["last_poll_status"] = existing.get("last_poll_status")
         config_data["last_poll_message"] = existing.get("last_poll_message")
-        goodreadsdb.update(config_data, Query().doc_type == CONFIG_DOC_ID)
+        goodreadsdb.update(config_data, (q.doc_type == CONFIG_DOC_TYPE) & (q.user_id == user_id))
     else:
         goodreadsdb.insert(config_data)
     
-    return get_config()
+    return get_config(user_id)
 
 
-def update_poll_status(status: str, message: str = "") -> None:
-    """Update the last poll status."""
+def update_poll_status(user_id: str, status: str, message: str = "") -> None:
+    """Update the last poll status for a specific user."""
+    q = Query()
     goodreadsdb.update(
         {
             "last_poll": datetime.utcnow().isoformat(),
             "last_poll_status": status,
             "last_poll_message": message,
         },
-        Query().doc_type == CONFIG_DOC_ID
+        (q.doc_type == CONFIG_DOC_TYPE) & (q.user_id == user_id)
     )
 
 
-def get_processed_book(book_id: str) -> Optional[Dict[str, Any]]:
-    """Get a processed book by its Goodreads book ID."""
-    return goodreadsdb.get(Query().book_id == book_id)
+def get_processed_book(user_id: str, book_id: str) -> Optional[Dict[str, Any]]:
+    """Get a processed book by its Goodreads book ID for a specific user."""
+    q = Query()
+    return goodreadsdb.get((q.user_id == user_id) & (q.book_id == book_id) & (q.doc_type == PROCESSED_DOC_TYPE))
 
 
-def get_all_processed_books() -> List[Dict[str, Any]]:
-    """Get all processed books."""
-    return goodreadsdb.search(Query().doc_type == "processed_book")
+def get_all_processed_books(user_id: str) -> List[Dict[str, Any]]:
+    """Get all processed books for a specific user."""
+    q = Query()
+    return goodreadsdb.search((q.doc_type == PROCESSED_DOC_TYPE) & (q.user_id == user_id))
 
 
 def add_processed_book(
+    user_id: str,
     book_id: str,
     title: str,
     author: str,
@@ -95,9 +169,11 @@ def add_processed_book(
     torrent_name: str = "",
     error_message: str = ""
 ) -> Dict[str, Any]:
-    """Add a book to the processed list."""
+    """Add a book to the processed list for a specific user."""
+    q = Query()
     book_data = {
-        "doc_type": "processed_book",
+        "doc_type": PROCESSED_DOC_TYPE,
+        "user_id": user_id,
         "book_id": book_id,
         "title": title,
         "author": author,
@@ -107,22 +183,24 @@ def add_processed_book(
         "error_message": error_message,
     }
     
-    existing = get_processed_book(book_id)
+    existing = get_processed_book(user_id, book_id)
     if existing:
-        goodreadsdb.update(book_data, Query().book_id == book_id)
+        goodreadsdb.update(book_data, (q.user_id == user_id) & (q.book_id == book_id))
     else:
         goodreadsdb.insert(book_data)
     
     return book_data
 
 
-def delete_processed_book(book_id: str) -> bool:
-    """Delete a processed book (allows re-download)."""
-    removed = goodreadsdb.remove(Query().book_id == book_id)
+def delete_processed_book(user_id: str, book_id: str) -> bool:
+    """Delete a processed book for a specific user (allows re-download)."""
+    q = Query()
+    removed = goodreadsdb.remove((q.user_id == user_id) & (q.book_id == book_id))
     return len(removed) > 0
 
 
-def clear_all_processed_books() -> int:
-    """Clear all processed books (allows re-downloading everything)."""
-    removed = goodreadsdb.remove(Query().doc_type == "processed_book")
+def clear_all_processed_books(user_id: str) -> int:
+    """Clear all processed books for a specific user (allows re-downloading everything)."""
+    q = Query()
+    removed = goodreadsdb.remove((q.doc_type == PROCESSED_DOC_TYPE) & (q.user_id == user_id))
     return len(removed)

--- a/source/abb/main.py
+++ b/source/abb/main.py
@@ -24,8 +24,8 @@ from .beetsapi import autoimport
 from .constants import BEETS_ERROR_LABEL, TRANSMISSION_URL, TRANSMISSION_USER, TRANSMISSION_PASS, DECYPHARR_URL, DECYPHARR_API_KEY, QBITTORRENT_URL, QBITTORRENT_USERNAME, QBITTORRENT_PASSWORD, TORRENT_CLIENT_TYPE, SESSION_KEY, TITLE, AUTH_MODE, GOODREADS_ENABLED
 from .db import select_candidate
 from .utils import custom_logger
-from .goodreads import poll_and_download, validate_goodreads_config
-from .goodreads_db import get_config as get_goodreads_config, save_config as save_goodreads_config, get_all_processed_books, delete_processed_book, clear_all_processed_books
+from .goodreads import poll_and_download, poll_and_download_single_user, validate_goodreads_config
+from .goodreads_db import get_config as get_goodreads_config, save_config as save_goodreads_config, get_all_processed_books, delete_processed_book, clear_all_processed_books, get_enabled_configs
 
 logger = custom_logger(__name__)
 
@@ -33,7 +33,7 @@ scheduler = BackgroundScheduler()
 
 
 class GoodreadsConfigRequest(BaseModel):
-    user_id: str
+    goodreads_user_id: str
     shelf: str = "to-read"
     poll_interval: int = 60
     enabled: bool = False
@@ -43,29 +43,27 @@ class CategoryRequest(BaseModel):
 
 def setup_goodreads_scheduler():
     """Setup or update the Goodreads polling scheduler based on current config."""
-    config = get_goodreads_config()
+    enabled_configs = get_enabled_configs()
     
-    # Remove existing Goodreads polling job if it exists
     scheduler.remove_all_jobs()
     
-    if config.get("enabled") and config.get("user_id"):
-        poll_interval = config.get("poll_interval", 60)
+    if enabled_configs:
+        min_poll_interval = min(config.get("poll_interval", 60) for config in enabled_configs)
         scheduler.add_job(
             poll_and_download,
             'interval',
-            minutes=poll_interval,
+            minutes=min_poll_interval,
             id='goodreads_poll',
             replace_existing=True
         )
         
-        # Ensure scheduler is running
         if not scheduler.running:
             scheduler.start()
             logger.info("Started Goodreads scheduler")
         
-        logger.info(f"Goodreads scheduler configured with {poll_interval} minute interval")
+        logger.info(f"Goodreads scheduler configured with {min_poll_interval} minute interval for {len(enabled_configs)} users")
     else:
-        logger.info("Goodreads scheduler disabled (not enabled or not configured)")
+        logger.info("Goodreads scheduler disabled (no enabled configurations)")
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -339,7 +337,7 @@ def autoimport_endpoint():
 def get_goodreads_config_endpoint(user: User = Depends(authenticate)):
     if not GOODREADS_ENABLED:
         raise HTTPException(status_code=404, detail="Goodreads integration is not enabled")
-    return get_goodreads_config()
+    return get_goodreads_config(user.id)
 
 @app.post("/goodreads/config")
 def save_goodreads_config_endpoint(config: GoodreadsConfigRequest, user: User = Depends(authenticate)):
@@ -348,7 +346,8 @@ def save_goodreads_config_endpoint(config: GoodreadsConfigRequest, user: User = 
     
     try:
         result = save_goodreads_config(
-            user_id=config.user_id,
+            user_id=user.id,
+            goodreads_user_id=config.goodreads_user_id,
             shelf=config.shelf,
             poll_interval=config.poll_interval,
             enabled=config.enabled
@@ -366,7 +365,7 @@ def validate_goodreads_endpoint(config: GoodreadsConfigRequest, user: User = Dep
     if not GOODREADS_ENABLED:
         raise HTTPException(status_code=404, detail="Goodreads integration is not enabled")
     
-    return validate_goodreads_config(config.user_id, config.shelf)
+    return validate_goodreads_config(config.goodreads_user_id, config.shelf)
 
 @app.post("/goodreads/poll")
 def trigger_goodreads_poll(user: User = Depends(authenticate)):
@@ -374,7 +373,7 @@ def trigger_goodreads_poll(user: User = Depends(authenticate)):
         raise HTTPException(status_code=404, detail="Goodreads integration is not enabled")
     
     try:
-        result = poll_and_download()
+        result = poll_and_download_single_user(user.id)
         return result
     except Exception as e:
         logger.error(f"Manual poll failed: {e}")
@@ -385,14 +384,14 @@ def get_processed_books(user: User = Depends(authenticate)):
     if not GOODREADS_ENABLED:
         raise HTTPException(status_code=404, detail="Goodreads integration is not enabled")
     
-    return get_all_processed_books()
+    return get_all_processed_books(user.id)
 
 @app.delete("/goodreads/books/{book_id}")
 def delete_processed_book_endpoint(book_id: str, user: User = Depends(authenticate)):
     if not GOODREADS_ENABLED:
         raise HTTPException(status_code=404, detail="Goodreads integration is not enabled")
     
-    if delete_processed_book(book_id):
+    if delete_processed_book(user.id, book_id):
         return {"status": "ok", "message": f"Book {book_id} removed from processed list"}
     else:
         raise HTTPException(status_code=404, detail=f"Book {book_id} not found")
@@ -402,7 +401,7 @@ def clear_all_processed_books_endpoint(user: User = Depends(authenticate)):
     if not GOODREADS_ENABLED:
         raise HTTPException(status_code=404, detail="Goodreads integration is not enabled")
     
-    count = clear_all_processed_books()
+    count = clear_all_processed_books(user.id)
     return {"status": "ok", "message": f"Cleared {count} processed books"}
 
 

--- a/static/index.html
+++ b/static/index.html
@@ -72,7 +72,7 @@
 
 
     goodreadsEnabled: false,
-    goodreadsConfig: { user_id: '', shelf: 'to-read', poll_interval: 60, enabled: false, last_poll: null, last_poll_status: null, last_poll_message: null },
+    goodreadsConfig: { goodreads_user_id: '', shelf: 'to-read', poll_interval: 60, enabled: false, last_poll: null, last_poll_status: null, last_poll_message: null },
     processedBooks: [],
     loadingGoodreads: false,
     goodreadsError: '',
@@ -376,7 +376,7 @@
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
-                    user_id: this.goodreadsConfig.user_id,
+                    goodreads_user_id: this.goodreadsConfig.goodreads_user_id,
                     shelf: this.goodreadsConfig.shelf,
                     poll_interval: this.goodreadsConfig.poll_interval,
                     enabled: this.goodreadsConfig.enabled
@@ -402,7 +402,7 @@
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
-                    user_id: this.goodreadsConfig.user_id,
+                    goodreads_user_id: this.goodreadsConfig.goodreads_user_id,
                     shelf: this.goodreadsConfig.shelf
                 })
             });
@@ -795,7 +795,7 @@
             <div class="space-y-3">
                 <div>
                     <label class="block text-sm text-gray-400 mb-1">Goodreads User ID</label>
-                    <input type="text" x-model="goodreadsConfig.user_id" class="w-full p-2 rounded bg-gray-600 text-white" placeholder="e.g., 54722780">
+                    <input type="text" x-model="goodreadsConfig.goodreads_user_id" class="w-full p-2 rounded bg-gray-600 text-white" placeholder="e.g., 54722780">
                 </div>
                 
                 <div>
@@ -823,7 +823,7 @@
                     <span x-show="loadingGoodreads && !pollingNow" class="animate-spin border-2 border-white border-t-transparent rounded-full w-4 h-4"></span>
                     Save
                 </button>
-                <button @click="triggerPoll()" :disabled="pollingNow || !goodreadsConfig.user_id" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded flex items-center gap-2 disabled:opacity-50">
+                <button @click="triggerPoll()" :disabled="pollingNow || !goodreadsConfig.goodreads_user_id" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded flex items-center gap-2 disabled:opacity-50">
                     <span x-show="pollingNow" class="animate-spin border-2 border-white border-t-transparent rounded-full w-4 h-4"></span>
                     Poll Now
                 </button>


### PR DESCRIPTION
## Summary

- Each user now has their own Goodreads config and processed books list
- Existing single-user config is automatically migrated to admin user on startup
- Scheduler polls all enabled users at the minimum configured interval

## Changes

### Database (`goodreads_db.py`)
- Added `user_id` field to config and processed book records
- Renamed `user_id` → `goodreads_user_id` to distinguish app user from Goodreads user ID
- Added automatic migration for existing configs (assigns to admin)
- New functions: `get_all_configs()`, `get_enabled_configs()`

### Business Logic (`goodreads.py`)
- `poll_and_download()` now iterates all enabled user configs
- Added `poll_and_download_for_user()` and `poll_and_download_single_user()`
- Downloads tagged with user ID for tracking

### API (`main.py`)
- All `/goodreads/*` endpoints now scoped to authenticated user
- Manual poll triggers only for current user
- Scheduler uses minimum poll interval across all enabled users

### Frontend (`index.html`)
- Updated field binding from `user_id` to `goodreads_user_id`